### PR TITLE
Add Docker runtime for running scheduled backups

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+.gitignore
+README.md
+*.log
+node_modules
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM alpine:3.20
+
+RUN apk add --no-cache \
+  bash \
+  curl \
+  rclone \
+  cronie \
+  tzdata
+
+WORKDIR /app
+
+# Where users mount their scripts
+VOLUME ["/scripts", "/config", "/data"]
+
+# Default cron location
+COPY example/crontab /etc/crontabs/root
+
+CMD ["crond", "-f"]
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: "3.8"
+
+services:
+  backup:
+    build: .
+    volumes:
+      - ./scripts:/scripts
+      - ./config:/config
+      - ./data:/data

--- a/example/backup.sh
+++ b/example/backup.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo "Running example backup at $(date)"

--- a/example/crontab
+++ b/example/crontab
@@ -1,0 +1,1 @@
+0 2 * * 0 /scripts/backup.sh >> /data/backup.log 2>&1


### PR DESCRIPTION
This PR adds optional Docker support to make running personal cloud backups
simpler and reproducible.

### What’s included
- Alpine-based Docker image with rclone + cron
- Example scripts and crontab
- Optional docker-compose setup

The image does not assume any specific backup implementation and works
with the existing documentation-first approach of the repository.
